### PR TITLE
Add Cloud_Optical_Thickness to viirs_l2.yaml

### DIFF
--- a/satpy/etc/readers/viirs_l2.yaml
+++ b/satpy/etc/readers/viirs_l2.yaml
@@ -104,6 +104,15 @@ datasets:
     file_type: cldprop_l2_viirs
     standard_name: cloud_top_height
 
+  Cloud_Optical_Thickness:
+    name: Cloud_Optical_Thickness
+    long_name: Cloud Optical Thickness two-channel retrieval using 2.2 um and either 0.65 um, 0.86 um or 1.24um (specified in Quality_Assurance) from best points: not failed in any way, not marked for clear sky restoral
+    units: '1'
+    coordinates: [cld_lon,cld_lat]
+    file_key: geophysical_data/Cloud_Optical_Thickness
+    file_type: cldprop_l2_viirs
+    standard_name: cloud_optical_thickness
+
 ##########################################
 # Datasets in files aerdb_l2_viirs
 ##########################################


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Add the cloud optical thickness derived from the two channel retrieval to the CLDPROP_L2 reader.

 - [x] Adds to #2729<!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
